### PR TITLE
Sync users.member flag from ifta_members table

### DIFF
--- a/app/models/ifta_member.rb
+++ b/app/models/ifta_member.rb
@@ -5,6 +5,10 @@ class IftaMember < ActiveRecord::Base
   #validations
   validates :email, :uniqueness => { :case_sensitive => false }
 
+  #callbacks
+  after_create :activate_matching_user
+  after_destroy :deactivate_matching_user
+
   def self.add_new_members(raw_emails)
     create(emails_to_members_array(raw_emails))
   end
@@ -12,6 +16,13 @@ class IftaMember < ActiveRecord::Base
   def self.replace_all_members_with(raw_emails)
     delete_all
     import(emails_to_members_array(raw_emails))
+    sync_all_user_member_status!
+  end
+
+  def self.sync_all_user_member_status!
+    member_emails = pluck(:email)
+    User.where(email: member_emails).update_all("member = TRUE, ifta_member_email = email")
+    User.where.not(email: member_emails).where(member: true).update_all(member: false, ifta_member_email: nil)
   end
 
 
@@ -23,5 +34,13 @@ class IftaMember < ActiveRecord::Base
   def self.emails_to_members_array (raw_emails)
     raw_emails = raw_emails.strip.downcase
     raw_emails.split(/[\s]*[\,\s]+[\s]*/).uniq.map { |email| {:email => email}}
+  end
+
+  def activate_matching_user
+    User.where("LOWER(email) = ?", email.downcase).update_all("member = TRUE, ifta_member_email = email")
+  end
+
+  def deactivate_matching_user
+    User.where("LOWER(email) = ?", email.downcase).update_all(member: false, ifta_member_email: nil)
   end
 end


### PR DESCRIPTION
## Summary
- Adding an email to the IFTA members list never updated `users.member`, so users with valid IFTA membership still saw non-member pricing
- The `users.member` boolean and `ifta_members` table were completely disconnected — pricing queries use `WHERE member = ?` against the user record, not the members list
- Added `after_create`/`after_destroy` callbacks on `IftaMember` to sync the matching user's `member` flag and `ifta_member_email`
- Added `sync_all_user_member_status!` called from `replace_all_members_with`, since that path uses `delete_all` + `import` which bypass ActiveRecord callbacks

## Test plan
- [ ] Add an email to the members list via /members/index → verify the matching user's itinerary now shows member pricing
- [ ] Remove an email from the members list → verify that user reverts to non-member pricing
- [ ] Replace the full members list → verify members in the new list get member pricing, removed members lose it
- [ ] Run existing `IftaMember` specs: `bundle exec rspec spec/models/ifta_member_spec.rb`